### PR TITLE
Adds terminal arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
  Steps through a directory and outputs a count of each filetype inside.
 
-* Asks for a directory via drag-and-drop.
+* Gets directory containing the files.
+	* Checks for directory to be passed with terminal command. (sys.argv[1])
+	* Asks for a directory via input/drag-and-drop if not found in terminal command.
 * Walks through the directory and subdirectories and generates a dictionary of extensions and their counts.
 * Displays the totals for each extension to the console.
 * (Optionally) Outputs a file ("file_counts.txt") to the User's Downloads folder with the extensions and counts.

--- a/countfiles/countfiles.py
+++ b/countfiles/countfiles.py
@@ -1,4 +1,6 @@
 import os
+import sys
+
 from pathlib import Path
 
 import dropfile
@@ -58,14 +60,18 @@ def write_file(fdir, fdict) -> None:
 def main() -> None:
     """
     Generates a empty dictionary to use, gets directory of files, 
-    and calls the other needed funcitons. 
+    and calls the other needed functions. 
     """
     files = {}
-    directory = dropfile.get()
+    # Gets directory from terminal input if present, if not get from user
+    try:
+        directory = sys.argv[1]
+    except IndexError:
+        directory = dropfile.get()
 
     get_counts(directory, files)
     display_totals(directory, files)
-
+    # Outputs list of file types to a text file in User's Downloads folder
     usersel = input("\n Output file? (y/n): ")
     if usersel.lower() == 'y':
         write_file(directory, files)


### PR DESCRIPTION
Adds the option to pass a source directory location via terminal when running initial command. 

Ex: 
```bash
$ python3 countfiles /root
```

Still asks for directory via user input if not passed at runtime. 